### PR TITLE
Store login info as cookie instead of local storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4548,6 +4548,11 @@
         }
       }
     },
+    "js-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
+      "integrity": "sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s="
+    },
     "js-levenshtein": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "embedjs": "0.0.11",
     "express": "^4.16.4",
     "google-map-react": "^1.1.2",
+    "js-cookie": "^2.2.0",
     "jss": "^9.8.7",
     "next": "^7.0.2",
     "notistack": "^0.4.1",

--- a/pages/login.js
+++ b/pages/login.js
@@ -13,14 +13,16 @@ class Login extends Component {
   static async getInitialProps({ req }) {
     const access_token = req.query.access_token;
     const username = req.query.username;
-    return { access_token, username };
+    const expires_in = req.query.expires_in;
+    return { access_token, username, expires_in };
   }
   componentDidMount() {
     const access_token = this.props.access_token;
     const username = this.props.username;
+    const expires_in = this.props.expires_in;
     if (access_token != undefined) {
-      setToken(access_token);
-      setUser(username);
+      setToken(access_token, expires_in);
+      setUser(username, expires_in);
     }
     this.setState({ user: username });
   }
@@ -59,7 +61,8 @@ class Login extends Component {
 
 Login.propTypes = {
   access_token: PropTypes.string,
-  username: PropTypes.string
+  username: PropTypes.string,
+  expires_in: PropTypes.number
 };
 
 export default Login;

--- a/utils/token.js
+++ b/utils/token.js
@@ -1,16 +1,19 @@
+import Cookie from "js-cookie";
 import api from "./SteemConnectAPI";
 
-export const setToken = token => {
-  localStorage.setItem("access_token", token);
+export const setToken = (token, expires_in) => {
+  const expiry = new Date(new Date().getTime() + expires_in * 1000);
+  Cookie.set("access_token", token, { expires: expiry });
 };
-export const setUser = username => {
-  localStorage.setItem("username", username);
+export const setUser = (username, expires_in) => {
+  const expiry = new Date(new Date().getTime() + expires_in * 1000);
+  Cookie.set("username", username, { expires: expiry });
 };
-export const getUser = () => localStorage.getItem("username");
-export const getToken = () => localStorage.getItem("access_token");
+export const getUser = () => Cookie.get("username");
+export const getToken = () => Cookie.get("access_token");
 export const logout = () => {
-  localStorage.removeItem("access_token");
-  localStorage.removeItem("username");
+  Cookie.remove("access_token");
+  Cookie.remove("username");
   api.revokeToken();
 };
 export const getLoginURL = api.getLoginURL();


### PR DESCRIPTION
Cookie gets the expiry date passed by Steemconnect. This fixes a bug where a user stays logged in even if the token is expired.